### PR TITLE
Add additional linting rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,13 @@
 			"jest": true,
 			"node": true,
 			"es6": true
+		},
+		"rules": {
+			  "prefer-const": "error",
+			  "semi": "error",
+			  "no-var": "error",
+			  "no-shadow": "error",
+			  "object-shorthand": "error"
 		}
 	},
 	"resolutions": {


### PR DESCRIPTION
- Prefer const when not reassigning - https://eslint.org/docs/rules/prefer-const
- Make semicolons required, though prettier does this for us - https://eslint.org/docs/rules/semi
- Don't use var, prefer let/const - https://eslint.org/docs/rules/no-var
- Don't shadow variables - https://eslint.org/docs/rules/no-shadow
- Prefer object shorthand - https://eslint.org/docs/rules/object-shorthand

This will introduce some lint errors that need fixing. Some can be fixed automatically by eslint:

```
npm run lint -- --fix
```