### PR TITLE
BUG: The user is shown the connection error notification when they first log into the kiosk

### DIFF
--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -9,8 +9,8 @@ import PropTypes from 'prop-types';
 
 class Home extends React.Component {
   componentDidMount() {
-    this.props.loadStoreList().catch(this.error);
-    this.props.loadUsers().catch(this.error);
+    this.props.loadStoreList().catch(this.handleError);
+    this.props.loadUsers().catch(this.handleError);
   }
 
   handleSnackChatClick = () => {
@@ -23,7 +23,7 @@ class Home extends React.Component {
     this.props.history.replace('/disclaimer');
   };
 
-  error = error => {
+  handleError = error => {
     if (error.code !== 'unauthenticated') this.props.history.replace('/error');
   };
 

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -23,8 +23,8 @@ class Home extends React.Component {
     this.props.history.replace('/disclaimer');
   };
 
-  error = () => {
-    this.props.history.replace('/error');
+  error = error => {
+    if (error.code !== 'unauthenticated') this.props.history.replace('/error');
   };
 
   render() {

--- a/src/components/WebcamCapture/WebcamCapture.test.js
+++ b/src/components/WebcamCapture/WebcamCapture.test.js
@@ -8,19 +8,19 @@ configure({adapter: new Adapter()});
 
 describe('<WebcamCapture />', () => {
   it('Renders webcam with screenshot width of 4/3 * imgSize', () => {
-    const wrapper = shallow(<WebcamCapture imgSize={300} />);
+    const wrapper = shallow(<WebcamCapture imgSize={300} onFail={jest.fn()} />);
     wrapper.setState({isDetecting: false});
     expect(wrapper.find(Webcam).props().screenshotWidth).toEqual(400);
   });
 
   it('Renders webcam with screenshot format of jpeg', () => {
-    const wrapper = shallow(<WebcamCapture imgSize={300} />);
+    const wrapper = shallow(<WebcamCapture imgSize={300} onFail={jest.fn()} />);
     wrapper.setState({isDetecting: false});
     expect(wrapper.find(Webcam).props().screenshotFormat).toEqual('image/jpeg');
   });
 
   it('Renders file input when fakeWebcam state is set', () => {
-    const wrapper = shallow(<WebcamCapture imgSize={300} />);
+    const wrapper = shallow(<WebcamCapture imgSize={300} onFail={jest.fn()} />);
     wrapper.setState({
       isDetecting: false,
       cameraConnected: true,


### PR DESCRIPTION
Fix for this doesn't redirect to the error page from `/home` if the error code from slack is `unauthenticated`
Assumes that the user must be authenticated to get as far as the home page.

# Checklist:

Related work items: #342

Preview url: [TODO | N/A]

- [ ] Tests have been added for new functionality
- [ ] Work has been reviewed by other team members
- [ ] Work has been reviewed by @craigayre or @eclennett
